### PR TITLE
Add message truncation to BufferedLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,23 +102,22 @@ config.rackstash.tags = ['ruby', 'rails2']
 
 # Additional fields which are included into each log event that
 # originates from a captured request.
-# Can either be a Hash or an object which responds to to_proc which
-# subsequently returns a Hash. If it is the latter, the proc will be exceuted
-# similar to an after filter in every request of the controller and thus has
-# access to the controller state after the request was handled.
-config.rackstash.request_fields = lambda do |controller|
+# Can either be a Hash or a callable object which responds to #call and which
+# subsequently returns a Hash. If it is the latter, the object will called
+# with the `request` object after the request is handled.
+config.rackstash.request_fields = lambda { |request|
   {
     :host => request.host,
     :source_ip => request.remote_ip,
     :user_agent => request.user_agent
   }
-end
+}
 
 # Additional fields that are to be included into every emitted log, both
 # buffered and not. You can use this to add global state information to the
 # log, e.g. from the current thread or from the current environment.
-# Similar to the request_fields, this can be either a static Hash or an
-# object which responds to to_proc and returns a Hash there.
+# Similar to the request_fields, this can be either a static Hash or a
+# callable object which responds to #call and returns a Hash.
 #
 # Note that the proc is not executed in a controller instance and thus doesn't
 # directly have access to the controller state.

--- a/lib/rackstash.rb
+++ b/lib/rackstash.rb
@@ -24,12 +24,9 @@ module Rackstash
   mattr_writer :request_fields
   self.request_fields = HashWithIndifferentAccess.new
   def self.request_fields(controller)
-    if @@request_fields.respond_to?(:call)
-      ret = controller.instance_eval(&@@request_fields)
-    else
-      ret = @@request_fields
-    end
-    HashWithIndifferentAccess.new(ret)
+    fields = @@request_fields
+    fields = fields.call(controller.request) if fields.respond_to?(:call)
+    HashWithIndifferentAccess.new(fields)
   end
 
   # Custom fields that will be merged with every log object, be it a captured
@@ -42,12 +39,9 @@ module Rackstash
   mattr_writer :fields
   self.fields = HashWithIndifferentAccess.new
   def self.fields
-    if @@fields.respond_to?(:call)
-      ret = @@fields.call
-    else
-      ret = @@fields
-    end
-    HashWithIndifferentAccess.new(ret)
+    fields = @@fields
+    fields = fields.call if fields.respond_to?(:call)
+    HashWithIndifferentAccess.new(fields)
   end
 
   # The source attribute in the generated Logstash output

--- a/lib/rackstash.rb
+++ b/lib/rackstash.rb
@@ -63,6 +63,22 @@ module Rackstash
   end
   self.tags = []
 
+  def self.with_tags(*tags)
+    if block_given?
+      begin
+        original_tags = self.tags
+        with_log_buffer do
+          self.tags = self.tags + tags.map(&:to_s)
+          yield
+        end
+      ensure
+        self.tags = original_tags
+      end
+    else
+      self.tags = self.tags + tags.map(&:to_s)
+    end
+  end
+
   def self.with_log_buffer(&block)
     if Rackstash.logger.respond_to?(:with_buffer)
       Rackstash.logger.with_buffer(&block)

--- a/lib/rackstash/buffered_logger.rb
+++ b/lib/rackstash/buffered_logger.rb
@@ -113,6 +113,10 @@ module Rackstash
       buffer && buffer[:tags]
     end
 
+    def tagged(*tags)
+      Rackstash.tagged(*tags) { yield }
+    end
+
     def source=(value)
       @source = value
       @source_is_customized = true

--- a/lib/rackstash/framework/base.rb
+++ b/lib/rackstash/framework/base.rb
@@ -4,9 +4,12 @@ module Rackstash
       def setup(config={})
         Rackstash.request_fields = config.rackstash[:request_fields]
         Rackstash.fields = config.rackstash[:fields] || HashWithIndifferentAccess.new
+
         Rackstash.source = config.rackstash[:source]
         Rackstash.log_level = config.rackstash[:log_level] || :info
+
         Rackstash.tags = config.rackstash[:tags] || []
+        Rackstash.request_tags = config.rackstash[:request_tags] || []
       end
     end
   end

--- a/lib/rackstash/framework/rails3.rb
+++ b/lib/rackstash/framework/rails3.rb
@@ -31,10 +31,14 @@ module Rackstash
         # ActionDispatch captures exceptions too early for us to catch
         # Thus, we inject our own exceptions_app to be able to catch the
         # actual backtrace and add it to the fields
-        exceptions_app = config.exceptions_app || ActionDispatch::PublicExceptions.new(Rails.public_path)
-        config.exceptions_app = lambda do |env|
-          log_subscriber._extract_exception_backtrace(env)
-          exceptions_app.call(env)
+        if config.respond_to?(:exceptions_app)
+          exceptions_app = config.exceptions_app || ActionDispatch::PublicExceptions.new(Rails.public_path)
+          config.exceptions_app = lambda do |env|
+            log_subscriber._extract_exception_backtrace(env)
+            exceptions_app.call(env)
+          end
+        else
+          # TODO: figure out how to get exceptions in rails 3.0-3.1
         end
 
         ActionController::Base.send :include, Rackstash::Instrumentation

--- a/lib/rackstash/log_subscriber.rb
+++ b/lib/rackstash/log_subscriber.rb
@@ -14,6 +14,8 @@ module Rackstash
 
       Rails.logger.fields.reverse_merge!(data)
       Rails.logger.fields.merge! request_fields(payload)
+
+      Rails.logger.tags.push *request_tags(payload)
     end
 
     def redirect_to(event)
@@ -98,6 +100,10 @@ module Rackstash
       end
     end
 
+    def request_tags(payload)
+      payload[:rackstash_request_tags] || []
+    end
+
     def request_fields(payload)
       payload[:rackstash_request_fields] || {}
     end
@@ -108,6 +114,7 @@ module Rackstash
 
     def append_info_to_payload(payload)
       super
+      payload[:rackstash_request_tags] = Rackstash.request_tags(self)
       payload[:rackstash_request_fields] = Rackstash.request_fields(self)
     end
   end

--- a/lib/rackstash/rails_ext/action_controller.rb
+++ b/lib/rackstash/rails_ext/action_controller.rb
@@ -84,6 +84,9 @@ module Rackstash
 
           request_fields = Rackstash.request_fields(self)
           logger.fields.merge!(request_fields) if request_fields
+
+          request_tags = Rackstash.request_tags(self)
+          logger.tags.push *request_tags
         end
       end
 

--- a/lib/rackstash/version.rb
+++ b/lib/rackstash/version.rb
@@ -1,3 +1,3 @@
 module Rackstash
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/lib/rackstash/version.rb
+++ b/lib/rackstash/version.rb
@@ -1,3 +1,3 @@
 module Rackstash
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/lib/rackstash/version.rb
+++ b/lib/rackstash/version.rb
@@ -1,3 +1,3 @@
 module Rackstash
-  VERSION = "0.3.0"
+  VERSION = "0.3.0.basecamp"
 end

--- a/lib/rackstash/version.rb
+++ b/lib/rackstash/version.rb
@@ -1,3 +1,3 @@
 module Rackstash
-  VERSION = "0.3.0.basecamp"
+  VERSION = "0.3.1.basecamp"
 end

--- a/lib/rackstash/version.rb
+++ b/lib/rackstash/version.rb
@@ -1,3 +1,3 @@
 module Rackstash
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/test/buffered_logger_test.rb
+++ b/test/buffered_logger_test.rb
@@ -139,6 +139,14 @@ describe Rackstash::BufferedLogger do
       json["@message"].must_equal "   [INFO] Hello"
     end
 
+    it "can set additional tags for the duration of a block" do
+      subject.tagged("foo", "bar") { subject.info "Testing" }
+      json["@tags"].must_equal ["foo", "bar"]
+
+      subject.info "Testing"
+      json["@tags"].must_equal []
+    end
+
     it "can set additional fields" do
       subject.with_buffer do
         subject.fields[:foo] = :bar

--- a/test/rackstash_test.rb
+++ b/test/rackstash_test.rb
@@ -50,9 +50,7 @@ describe Rackstash do
     end
 
     let(:controller) do
-      controller = Class.new(Object){attr_accessor :status}.new
-      controller.status = "running"
-      controller
+      Struct.new(:request).new(Struct.new(:status).new(200))
     end
 
     it "won't be included in unbuffered mode" do
@@ -72,31 +70,29 @@ describe Rackstash do
     end
 
     it "can be defined as a proc" do
-      Rackstash.request_fields = proc do |controller|
+      Rackstash.request_fields = proc do |request|
         {
           :foo => :bar,
-          :status => @status,
-          :instance_status => controller.status
+          :status => request.status
         }
       end
 
       Rackstash.request_fields(controller).must_be_instance_of HashWithIndifferentAccess
-      Rackstash.request_fields(controller).must_equal({"foo" => :bar, "status" => "running", "instance_status" => "running"})
+      Rackstash.request_fields(controller).must_equal({"foo" => :bar, "status" => 200})
 
       # TODO: fake a real request and ensure that the field gets set in the log output
     end
 
     it "can be defined as a lambda" do
-      Rackstash.request_fields = lambda do |controller|
+      Rackstash.request_fields = lambda do |request|
         {
           :foo => :bar,
-          :status => @status,
-          :instance_status => controller.status
+          :status => request.status
         }
       end
 
       Rackstash.request_fields(controller).must_be_instance_of HashWithIndifferentAccess
-      Rackstash.request_fields(controller).must_equal({"foo" => :bar, "status" => "running", "instance_status" => "running"})
+      Rackstash.request_fields(controller).must_equal({"foo" => :bar, "status" => 200})
 
       # TODO: fake a real request and ensure that the field gets set in the log output
     end


### PR DESCRIPTION
When Rackstash.max_message_bytesize is set (default 1MB), messages exceeding the limit are truncated with head/tail preservation using a "... (truncated) ..." marker. Truncation is byte-level and UTF-8 safe, walking past continuation bytes to avoid splitting multi-byte characters.

Setting max_message_bytesize to nil or 0 disables truncation.